### PR TITLE
Changed ssl protocol version for client

### DIFF
--- a/briefdruckzentrum/adapters.py
+++ b/briefdruckzentrum/adapters.py
@@ -1,0 +1,16 @@
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.poolmanager import PoolManager
+
+
+class SSLAdapter(HTTPAdapter):
+    """An HTTPS Transport Adapter that uses an arbitrary SSL version."""
+    def __init__(self, ssl_version=None, **kwargs):
+        self.ssl_version = ssl_version
+
+        super(SSLAdapter, self).__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(num_pools=connections,
+                                       maxsize=maxsize,
+                                       block=block,
+                                       ssl_version=self.ssl_version)

--- a/briefdruckzentrum/api.py
+++ b/briefdruckzentrum/api.py
@@ -4,9 +4,11 @@ from __future__ import (unicode_literals, absolute_import)
 import logging
 
 import requests
+import ssl
 import xmltodict
 from money import Money
 
+from briefdruckzentrum.adapters import SSLAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +116,7 @@ class Order(object):
 class Client(object):
     def __init__(self, user, password):
         self.session = requests.Session()
+        self.session.mount('https://', SSLAdapter(ssl_version=ssl.PROTOCOL_TLSv1))
         self.session.auth = (user, password)
         self.session.verify = True
 


### PR DESCRIPTION
Due to problems with https://www.briefdruckzentrum.de SSL Certificate, we forcing to use TLSv1 for client.
