### PR TITLE
Set explicit ciphers for ssl connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+branches:
+  only:
+  - master
 python:
 - '2.7'
 - '3.4'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://travis-ci.org/Thermondo/python-briefdruckzentrum.svg)](https://travis-ci.org/Thermondo/python-briefdruckzentrum)
 [![Coverage Status](https://img.shields.io/coveralls/Thermondo/python-briefdruckzentrum.svg)](https://coveralls.io/r/Thermondo/python-briefdruckzentrum?branch=master)
-[![License](https://pypip.in/license/python-briefdruckzentrum/badge.svg)](https://pypi.python.org/pypi/python-briefdruckzentrum/)
-[![Latest Version](https://pypip.in/version/python-briefdruckzentrum/badge.svg)](https://pypi.python.org/pypi/python-briefdruckzentrum/)
+[![PyPI](https://img.shields.io/pypi/v/python-briefdruckzentrum.svg)](https://pypi.python.org/pypi/python-briefdruckzentrum/)
 
 python-briefdruckzentrum
 ========================

--- a/briefdruckzentrum/adapters.py
+++ b/briefdruckzentrum/adapters.py
@@ -1,16 +1,16 @@
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+from requests.packages.urllib3.util.ssl_ import create_urllib3_context
+
+
+CIPHERS = 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:DES-CBC3-SHA:ECDH+AES128:DH+AES:ECDH+HIGH' \
+          ':DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:!aNULL:!eNULL:!MD5'
 
 
 class SSLAdapter(HTTPAdapter):
-    """An HTTPS Transport Adapter that uses an arbitrary SSL version."""
-    def __init__(self, ssl_version=None, **kwargs):
-        self.ssl_version = ssl_version
-
-        super(SSLAdapter, self).__init__(**kwargs)
-
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(num_pools=connections,
-                                       maxsize=maxsize,
-                                       block=block,
-                                       ssl_version=self.ssl_version)
+    """Custom HTTPS Transport Adapter that uses cipher, supported by Briefdruckzentrum."""
+    def init_poolmanager(self, connections, maxsize, block, *args, **kwargs):
+        context = create_urllib3_context(ciphers=CIPHERS)
+        kwargs['ssl_context'] = context
+        return super(SSLAdapter, self).init_poolmanager(
+            connections, maxsize, block, *args, **kwargs
+        )

--- a/briefdruckzentrum/api.py
+++ b/briefdruckzentrum/api.py
@@ -4,7 +4,6 @@ from __future__ import (unicode_literals, absolute_import)
 import logging
 
 import requests
-import ssl
 import xmltodict
 from money import Money
 
@@ -116,7 +115,7 @@ class Order(object):
 class Client(object):
     def __init__(self, user, password):
         self.session = requests.Session()
-        self.session.mount('https://', SSLAdapter(ssl_version=ssl.PROTOCOL_TLSv1))
+        self.session.mount('https://', SSLAdapter())
         self.session.auth = (user, password)
         self.session.verify = True
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class PyTest(Command):
 
 setup(
     name='python-briefdruckzentrum',
-    version='0.1.3',
+    version='0.1.4',
     description='a lightweight python wrapper for briefdruckzentrum.de API',
     author='codingjoe',
     url='https://github.com/Thermondo/python-briefdruckzentrum',
@@ -45,7 +45,7 @@ setup(
     ],
     packages=['briefdruckzentrum'],
     include_package_data=True,
-    install_requires=['requests>=2.3', 'xmltodict>=0.9', 'money>=1.2'],
+    install_requires=['requests>=2.12', 'xmltodict>=0.9', 'money>=1.2'],
     tests_require=['pytest', 'pytest-pep8', 'pytest-flakes'],
     cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
There are several issues related to fresh requests versions (>=2.12):
https://github.com/requests/requests/issues/3608

And the problem here is a bad `briefdruckzentrum.de` TLS setup.
Since we mostly cannot do anything there, we can just update library config to use this a bit outdated ciphers.